### PR TITLE
fix crash in device

### DIFF
--- a/Source/BFKit/BFLog.m
+++ b/Source/BFKit/BFLog.m
@@ -56,9 +56,9 @@ void ExtendNSLog(const char * _Nonnull file, int lineNumber, const char * _Nonnu
     NSString *log = [NSString stringWithFormat:@"%s:%d %s: %s", [fileName UTF8String], lineNumber, [functionName UTF8String], [body UTF8String]];
     fprintf(stderr, "%s %s:%d %s: %s", [[NSDate dateInformationDescriptionWithInformation:[[NSDate date] dateInformation] dateSeparator:@"-" usFormat:YES nanosecond:YES] UTF8String], [fileName UTF8String], lineNumber, [functionName UTF8String], [body UTF8String]);
     
-    logString = [logString stringByAppendingString:[NSString stringWithFormat:@"%@", body]];
+    logString = [NSString stringWithFormat:@"%@,%@",logString,body];
     
-    logDetailedString = [logDetailedString stringByAppendingString:[NSString stringWithFormat:@"%@", log]];
+    logDetailedString = [NSString stringWithFormat:@"%@,%@",logDetailedString,log];
 }
 
 + (NSString * _Nonnull)logString {


### PR DESCRIPTION
<img width="929" alt="debug" src="https://cloud.githubusercontent.com/assets/1468865/18041250/54259c00-6de9-11e6-8184-7ea54ef41f5d.png">
<img width="909" alt="bug" src="https://cloud.githubusercontent.com/assets/1468865/18041251/54285f80-6de9-11e6-8de2-f8ea7242ce6f.png">

fix stringByAppendingString crash in ios9.3.2 iPhone device, not crash in Simulator.