### PR TITLE
Makes the [UIApplication sharedApplication] call only if possible

### DIFF
--- a/Source/Additions/UIKit/UIScreen+BFKit.m
+++ b/Source/Additions/UIKit/UIScreen+BFKit.m
@@ -49,7 +49,7 @@
 
 	UIInterfaceOrientation orientation = UIInterfaceOrientationPortrait;
 	if([UIApplication instancesRespondToSelector:@selector(sharedApplication)]){
-		orientation = [UIApplication sharedApplication].statusBarOrientation;
+		orientation = [[[UIApplication class] performSelector:@selector(sharedApplication)] statusBarOrientation];
 	}
 
     if ((NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1) && UIInterfaceOrientationIsLandscape(orientation)) {

--- a/Source/Additions/UIKit/UIScreen+BFKit.m
+++ b/Source/Additions/UIKit/UIScreen+BFKit.m
@@ -46,8 +46,13 @@
 
 - (CGSize)fixedScreenSize {
     CGSize screenSize = self.bounds.size;
-    
-    if ((NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1) && UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
+
+	UIInterfaceOrientation orientation = UIInterfaceOrientationPortrait;
+	if([UIApplication instancesRespondToSelector:@selector(sharedApplication)]){
+		orientation = [UIApplication sharedApplication].statusBarOrientation;
+	}
+
+    if ((NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1) && UIInterfaceOrientationIsLandscape(orientation)) {
         return CGSizeMake(screenSize.height, screenSize.width);
     }
     

--- a/Source/Additions/UIKit/UIScreen+BFKit.m
+++ b/Source/Additions/UIKit/UIScreen+BFKit.m
@@ -47,15 +47,16 @@
 - (CGSize)fixedScreenSize {
     CGSize screenSize = self.bounds.size;
 
-	UIInterfaceOrientation orientation = UIInterfaceOrientationPortrait;
-	if([UIApplication instancesRespondToSelector:@selector(sharedApplication)]){
-		orientation = [[[UIApplication class] performSelector:@selector(sharedApplication)] statusBarOrientation];
-	}
+    UIInterfaceOrientation orientation = UIInterfaceOrientationPortrait;
+    Class UIApplicationClass = NSClassFromString(@"UIApplication");
+    if(UIApplicationClass && [UIApplicationClass respondsToSelector:@selector(sharedApplication)]) {
+        orientation = [[[UIApplication class] performSelector:@selector(sharedApplication)] statusBarOrientation];
+    }
 
     if ((NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1) && UIInterfaceOrientationIsLandscape(orientation)) {
         return CGSizeMake(screenSize.height, screenSize.width);
     }
-    
+
     return screenSize;
 }
 

--- a/Source/Additions/UIKit/UIWindow+BFKit.m
+++ b/Source/Additions/UIKit/UIWindow+BFKit.m
@@ -39,10 +39,11 @@ NSMutableDictionary *touchImages;
 - (UIImage * _Nonnull)takeScreenshotAndSave:(BOOL)save {
     BOOL ignoreOrientation = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0");
 
-	UIInterfaceOrientation orientation = UIInterfaceOrientationPortrait;
-	if(class_respondsToSelector([UIApplication class], @selector(sharedApplication))){
-		orientation = [[[UIApplication class] performSelector:@selector(sharedApplication)] statusBarOrientation];
-	}
+  UIInterfaceOrientation orientation = UIInterfaceOrientationPortrait;
+  Class UIApplicationClass = NSClassFromString(@"UIApplication");
+  if(UIApplicationClass && [UIApplicationClass respondsToSelector:@selector(sharedApplication)]) {
+    orientation = [[[UIApplication class] performSelector:@selector(sharedApplication)] statusBarOrientation];
+  }
     CGSize imageSize = CGSizeZero;
     if (UIInterfaceOrientationIsPortrait(orientation) || ignoreOrientation) {
         imageSize = [UIScreen mainScreen].bounds.size;

--- a/Source/Additions/UIKit/UIWindow+BFKit.m
+++ b/Source/Additions/UIKit/UIWindow+BFKit.m
@@ -38,9 +38,11 @@ NSMutableDictionary *touchImages;
 
 - (UIImage * _Nonnull)takeScreenshotAndSave:(BOOL)save {
     BOOL ignoreOrientation = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0");
-    
-    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
-    
+
+	UIInterfaceOrientation orientation = UIInterfaceOrientationPortrait;
+	if(class_respondsToSelector([UIApplication class], @selector(sharedApplication))){
+		orientation = [UIApplication sharedApplication].statusBarOrientation;
+	}
     CGSize imageSize = CGSizeZero;
     if (UIInterfaceOrientationIsPortrait(orientation) || ignoreOrientation) {
         imageSize = [UIScreen mainScreen].bounds.size;

--- a/Source/Additions/UIKit/UIWindow+BFKit.m
+++ b/Source/Additions/UIKit/UIWindow+BFKit.m
@@ -41,7 +41,7 @@ NSMutableDictionary *touchImages;
 
 	UIInterfaceOrientation orientation = UIInterfaceOrientationPortrait;
 	if(class_respondsToSelector([UIApplication class], @selector(sharedApplication))){
-		orientation = [UIApplication sharedApplication].statusBarOrientation;
+		orientation = [[[UIApplication class] performSelector:@selector(sharedApplication)] statusBarOrientation];
 	}
     CGSize imageSize = CGSizeZero;
     if (UIInterfaceOrientationIsPortrait(orientation) || ignoreOrientation) {


### PR DESCRIPTION
`[UIApplication sharedApplication]` call breaks in the extensions, the change allows the library to be included in extensions without problems.